### PR TITLE
tflint + checkov hotfix

### DIFF
--- a/05/demo/providers.tf
+++ b/05/demo/providers.tf
@@ -17,10 +17,10 @@ terraform {
     shared_credentials_files = ["~/.aws/credentials"]
 #    shared_config_files = ["~/.aws/config"]
     profile = "default"
-    region = "ru-central1"
+    region  = "ru-central1"
 
-    bucket = "littlelucidlynx-bucket" #FIO-netology-tfstate
-    key = "study/terraform.tfstate"
+    bucket  = "littlelucidlynx-bucket" #FIO-netology-tfstate
+    key     = "study/terraform.tfstate"
     
 
     # access_key                  = "..."          #Только для примера! Не хардкодим секретные данные!
@@ -33,8 +33,8 @@ terraform {
     skip_s3_checksum            = true # Необходимая опция при описании бэкенда для Terraform версии 1.6.3 и старше.
 
   endpoints ={
-    dynamodb = "https://docapi.serverless.yandexcloud.net/ru-central1/b1g393ugq43uqc1r3n8a/etno7gv7lbpp4nj56uaq"
-    s3 = "https://storage.yandexcloud.net"
+    dynamodb  = "https://docapi.serverless.yandexcloud.net/ru-central1/b1g393ugq43uqc1r3n8a/etno7gv7lbpp4nj56uaq"
+    s3        = "https://storage.yandexcloud.net"
   }
 
     dynamodb_table = "tfstate"
@@ -43,8 +43,14 @@ terraform {
   required_providers {
     yandex = {
       source  = "yandex-cloud/yandex"
-#      version = "0.118.0"
+      version = "0.130.0"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+
   }
 }
 
@@ -54,7 +60,6 @@ provider "yandex" {
   service_account_key_file = file(var.yc_ssh_key_path)
   zone                     = var.default_zone 
 }
-
 
 # For terraform <1.6.0
 # terraform {


### PR DESCRIPTION
```
eurus@ubnt-vm:~/ter-homeworks/05/demo$ tflint --recursive
1 issue(s) found:

Warning: Missing version constraint for provider "random" in `required_providers` (terraform_required_providers)

  on main.tf line 1:
   1: resource "random_password" "any_uniq_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.1/docs/rules/terraform_required_providers.md
```

***

```
eurus@ubnt-vm:~/ter-homeworks/05/demo$ checkov --directory ~/ter-homeworks/05/demo
[ terraform framework ]: 100%|████████████████████|[3/3], Current File Scanned=variables.tf
[ secrets framework ]: 100%|████████████████████|[3/3], Current File Scanned=/home/eurus/ter-homeworks/05/demo/variables.tf


       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.266 
Update available 3.2.266 -> 3.2.267
Run pip3 install -U checkov to update
```

***

```
eurus@ubnt-vm:~/ter-homeworks/05/demo$ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # random_password.any_uniq_name will be created
  + resource "random_password" "any_uniq_name" {
      + bcrypt_hash = (sensitive value)
      + id          = (known after apply)
      + length      = 20
      + lower       = true
      + min_lower   = 0
      + min_numeric = 0
      + min_special = 0
      + min_upper   = 0
      + number      = true
      + numeric     = true
      + result      = (sensitive value)
      + special     = true
      + upper       = true
    }

Plan: 1 to add, 0 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply"
now.
```